### PR TITLE
Add link to tardis documentation

### DIFF
--- a/_examples/tardis.md
+++ b/_examples/tardis.md
@@ -2,6 +2,7 @@
 name: TARDIS – Resourcemanager
 project-id: tardis
 subcaption: Transparent Adaptive Resource Dynamic Integration System
+documentation: https://cobald-tardis.readthedocs.io/en/latest/?badge=latest
 git: https://github.com/MatterMiners/tardis
 doi: http://doi.org/10.5281/zenodo.2240606
 logo: tardis_logo.svg


### PR DESCRIPTION
This pull request adds a link to the tardis documentation to the [matterminers.github.io](https://matterminers.github.io)

Cheers,
Manuel