### PR TITLE
Add optional parameter `date_end`. Add ACAT22 and FIDIUM events.

### DIFF
--- a/_events/20221020_fidium-bellecaching.yml
+++ b/_events/20221020_fidium-bellecaching.yml
@@ -1,0 +1,12 @@
+---
+title: XRootD Caching for Belle II at GridKa
+date: 2022-10-20 15:00 +0200
+presenter: Moritz Bauer
+author:
+  - Moritz Bauer
+type: Presentation
+event:
+  title: FIDIUM Collaboration Meeting 2022
+  location: Hamburg, Germany
+  href: https://indico.desy.de/event/35774/
+---

--- a/_events/20221020_fidium-cobaldtardis.yml
+++ b/_events/20221020_fidium-cobaldtardis.yml
@@ -1,0 +1,12 @@
+---
+title: Transparent expansion of WLCG compute sites using HPC resources
+date: 2022-10-20 15:00 +0200
+presenter: Ralf Florian von Cube
+author:
+  - Ralf Florian Von Cube
+type: Presentation
+event:
+  title: FIDIUM Collaboration Meeting 2022
+  location: Hamburg, Germany
+  href: https://indico.desy.de/event/35774/
+---

--- a/_events/20221024_acat-poster-bellecaching.yml
+++ b/_events/20221024_acat-poster-bellecaching.yml
@@ -5,10 +5,10 @@ date_end: 2022-10-28 12:00 +0200
 presenter: Moritz Bauer
 author:
   - Moritz Bauer
-    Gunter Quast
-    Manuel Giffels
-    Matthias Schnepf
-    Max Fischer
+  - Guenter Quast
+  - Manuel Giffels
+  - Matthias Schnepf
+  - Max Fischer
 type: Poster
 href: https://indico.cern.ch/event/1106990/contributions/4991307/
 event:

--- a/_events/20221024_acat-poster-bellecaching.yml
+++ b/_events/20221024_acat-poster-bellecaching.yml
@@ -1,0 +1,18 @@
+---
+title: XRootD caching for Belle II
+date: 2022-10-24 12:00 +0200
+date_end: 2022-10-28 12:00 +0200
+presenter: Moritz Bauer
+author:
+  - Moritz Bauer
+    Gunter Quast
+    Manuel Giffels
+    Matthias Schnepf
+    Max Fischer
+type: Poster
+href: https://indico.cern.ch/event/1106990/contributions/4991307/
+event:
+  title: 21st International Workshop on Advanced Computing and Analysis Techniques in Physics Research
+  location: Bari, Italy
+  href: https://indico.cern.ch/event/1106990/
+---

--- a/_events/20221024_acat-poster-cobaldtardis.yml
+++ b/_events/20221024_acat-poster-cobaldtardis.yml
@@ -5,14 +5,13 @@ date_end: 2022-10-28 12:00 +0200
 presenter: Ralf Florian von Cube
 author:
   - Ralf Florian Von Cube
-    Alexander Schmidt
-    Guenter Quast
-    Manuel Giffels
-    Andreas Nowack
-    Thomas Kress
-    Alexander Jung
-    Matthias Schnepf
-
+  - Alexander Schmidt
+  - Guenter Quast
+  - Manuel Giffels
+  - Andreas Nowack
+  - Thomas Kress
+  - Alexander Jung
+  - Matthias Schnepf
 type: Poster
 href: https://indico.cern.ch/event/1106990/contributions/4991258/
 event:

--- a/_events/20221024_acat-poster-cobaldtardis.yml
+++ b/_events/20221024_acat-poster-cobaldtardis.yml
@@ -1,0 +1,22 @@
+---
+title:  Transparent expansion of a WLCG compute site using HPC resources
+date: 2022-10-24 12:00 +0200
+date_end: 2022-10-28 12:00 +0200
+presenter: Ralf Florian von Cube
+author:
+  - Ralf Florian Von Cube
+    Alexander Schmidt
+    Guenter Quast
+    Manuel Giffels
+    Andreas Nowack
+    Thomas Kress
+    Alexander Jung
+    Matthias Schnepf
+
+type: Poster
+href: https://indico.cern.ch/event/1106990/contributions/4991258/
+event:
+  title: 21st International Workshop on Advanced Computing and Analysis Techniques in Physics Research
+  location: Bari, Italy
+  href: https://indico.cern.ch/event/1106990/
+---

--- a/_events/20221024_acat-poster-gpu.yml
+++ b/_events/20221024_acat-poster-gpu.yml
@@ -1,0 +1,18 @@
+---
+title: Optimized GPU usage in High Energy Physics applications
+date: 2022-10-24 12:00 +0200
+date_end: 2022-10-28 12:00 +0200
+presenter: Tim Voigtlaender
+author:
+  - Tim Voigtlaender
+    Guenter Quast
+    Manuel Giffels
+    Matthias Schnepf
+    Roger Wolf
+type: Poster
+href: https://indico.cern.ch/event/1106990/contributions/4991345/
+event:
+  title: 21st International Workshop on Advanced Computing and Analysis Techniques in Physics Research
+  location: Bari, Italy
+  href: https://indico.cern.ch/event/1106990/
+---

--- a/_events/20221024_acat-poster-gpu.yml
+++ b/_events/20221024_acat-poster-gpu.yml
@@ -5,10 +5,10 @@ date_end: 2022-10-28 12:00 +0200
 presenter: Tim Voigtlaender
 author:
   - Tim Voigtlaender
-    Guenter Quast
-    Manuel Giffels
-    Matthias Schnepf
-    Roger Wolf
+  - Guenter Quast
+  - Manuel Giffels
+  - Matthias Schnepf
+  - Roger Wolf
 type: Poster
 href: https://indico.cern.ch/event/1106990/contributions/4991345/
 event:

--- a/_events/20221024_acat-poster-simulation.yml
+++ b/_events/20221024_acat-poster-simulation.yml
@@ -1,0 +1,16 @@
+---
+title: Advancing Opportunistic Resource Management via Simulation
+date: 2022-10-24 12:00 +0200
+date_end: 2022-10-28 12:00 +0200
+presenter: Max Fischer
+author:
+  - Max Fischer
+co-author:
+  - Eileen Kuehn
+type: Poster
+href: https://indico.cern.ch/event/1106990/contributions/4991346/
+event:
+  title: 21st International Workshop on Advanced Computing and Analysis Techniques in Physics Research
+  location: Bari, Italy
+  href: https://indico.cern.ch/event/1106990/
+---

--- a/_includes/event-overview.html
+++ b/_includes/event-overview.html
@@ -1,6 +1,16 @@
 {% assign event = include.event-id %}
 <li style="margin-bottom: 5px;">
-	{{ event.date | date: '%B %d, %Y' }}: 
+  {% if event.date_end %}
+    {% assign start_year=event.date|date:'%Y' %}
+    {% assign end_year=event.date_end|date:'%Y' %}
+    {% if start_year == end_year %}
+      {{ event.date|date: '%B %d' }} - {{ event.date_end|date: '%B %d, %Y' }}:
+    {% else %}
+      {{ event.date|date: '%B %d, %Y' }} - {{ event.date_end|date: '%B %d, %Y' }}:
+    {% endif %}
+  {% else %}
+    {{ event.date|date: '%B %d, %Y' }}:
+  {% endif %}
   {{ event.type }} by {{ event.presenter }} about
   <em>
     {% if event.href %}<a class="white-text" href={{event.href}}>{{ event.title }}</a>


### PR DESCRIPTION
This PR implements the possibility to add a `date_end`-parameter for events lasting more than one day (e.g. poster sessions during a conference week).

It also adds the entries for the ACAT poster events and preliminary events for the FIDIUM collaboration meeting.